### PR TITLE
[FEAT] main.py 파일 분리 - 모델 로직과 검색 로직을 각각의 파일, 엔드포인트로 구조 개선

### DIFF
--- a/Back/main.py
+++ b/Back/main.py
@@ -1,209 +1,190 @@
+# uvicorn main:app --host 127.0.0.1 --port 8000
 from fastapi import FastAPI, File, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
+import requests, faiss, json, torch, io, os, logging
 import numpy as np
-from transformers import AutoModel
-from PIL import Image
-import io, os, requests, json, hashlib, torch
-from rembg import remove
-import faiss
+from contextlib import asynccontextmanager
 
 os.environ["KMP_DUPLICATE_LIB_OK"] = "True"
 
-app = FastAPI()
+# 로그
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
+# DB, FAISS 인덱스 초기화
+db_images = []
+db_embeddings = []
+index = None
+perfume_data = []
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    init()
+    yield
+
+app = FastAPI(lifespan=lifespan)
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],  # React 앱이 실행되는 도메인
+    allow_origins=["http://localhost:3000", "http://localhost:8080", "http://localhost:8001"],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
 )
 
-# 캐시 디렉토리 설정
-CACHE_DIR = "./image_cache"
-EMBEDDING_CACHE_DIR = "./embedding_cache"
-os.makedirs(CACHE_DIR, exist_ok=True)
-os.makedirs(EMBEDDING_CACHE_DIR, exist_ok=True)
+# 서버 시작 전 미리 실행할 코드; 서버를 initialize하여 데이터 로드, 이미지 다운로드, 임베딩 계산, FAISS 인덱스 생성을 미리 수행
+def init():
+    global db_images, db_embeddings, index, perfume_data
 
-# CLIP 모델 로드
-device = "cuda" if torch.cuda.is_available() else "cpu"
-model = AutoModel.from_pretrained("jinaai/jina-clip-v2", trust_remote_code=True).to(device)
+    # JSON 데이터 로드
+    perfume_image_data = load_json("./perfume_image.json", "perfume image")
+    perfume_data = load_json("./perfume.json", "perfume")
 
-# JSON 향수 정보 로드
-try:
-    with open("perfume_image.json", "r", encoding="utf-8") as f:
-        perfume_image_data = json.load(f)
-        print(f"Loaded {len(perfume_image_data)} items from JSON.")
-except Exception as e:
-    print(f"Failed to load JSON file: {e}")
-    perfume_image_data = []
-
-
-# URL 해시 생성 함수
-def generate_hash(url):
-    return hashlib.md5(url.encode("utf-8")).hexdigest()
-
-
-# URL에서 이미지를 다운로드하고 캐싱하는 함수
-def download_image_with_cache(url):
-    # URL에서 파일 이름과 확장자 추출
-    filename = os.path.basename(url.split("?")[0])  # 쿼리 파라미터 제거
-    local_path = os.path.join(CACHE_DIR, filename)
-
-    # 캐시에 이미지가 이미 있는지 확인
-    if os.path.exists(local_path):
-        print(f"Using cached image: {local_path}")
-        return Image.open(local_path).convert("RGB")
+    if not perfume_image_data or not perfume_data:
+        logger.error("Initialization failed due to missing or invalid JSON data.")
+        return
 
     # 이미지 다운로드
-    print(f"Downloading image: {url}")
-    response = requests.get(url, stream=True)
-    response.raise_for_status()
+    downloaded_images = download_images(perfume_image_data)
+    if not downloaded_images:
+        logger.error("Initialization failed due to image downloading errors.")
+        return
 
-    # 이미지 저장
-    with open(local_path, "wb") as f:
-        f.write(response.content)
+    # 임베딩 계산
+    embeddings_data = compute_embeddings(downloaded_images)
+    if not embeddings_data:
+        logger.error("Initialization failed due to embedding computation errors.")
+        return
 
-    # 로컬에서 이미지 열기
-    return Image.open(local_path).convert("RGB")
+    # DB에 이미지 및 임베딩 저장
+    populate_db(downloaded_images, embeddings_data)
 
+    # FAISS 인덱스 생성
+    create_faiss_index()
 
-# 임베딩 생성 함수
-def compute_embedding(image):
-    return model.encode_image(image)
-
-
-# 임베딩 캐싱 함수
-def get_or_compute_embedding(image, url):
-    # URL 기반으로 해시 생성
-    url_hash = generate_hash(url)
-    embedding_path = os.path.join(EMBEDDING_CACHE_DIR, f"{url_hash}.npy")
-
-    # 캐시된 임베딩 파일이 존재하면 불러오기
-    if os.path.exists(embedding_path):
-        print(f"Using cached embedding for URL: {url}")
-        return torch.tensor(np.load(embedding_path))
-
-    # 임베딩 생성
-    print(f"Computing embedding for URL: {url}")
-    embedding = compute_embedding(image).flatten()
-
-    # 임베딩 저장
-    np.save(embedding_path, embedding)
-    return embedding
-
-
-# 데이터베이스 이미지 임베딩 생성
-db_images = []
-db_embeddings = []
-
-for item in perfume_image_data:
+# 지정된 파일 경로에서 JSON 데이터를 로드
+def load_json(file_path, data_name):
     try:
-        # 이미지 다운로드 및 캐싱
-        image = download_image_with_cache(item["url"])
-        db_images.append({"id": item["id"], "url": item["url"]})
-
-        # 임베딩 생성 또는 캐싱된 값 불러오기
-        embedding = get_or_compute_embedding(image, item["url"])
-        db_embeddings.append(embedding)
+        with open(file_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+            logger.info(f"Loaded {len(data)} {data_name} data from JSON.")
+            return data
     except Exception as e:
-        print(f"Failed to process image ID {item['id']} from URL {item['url']}: {e}")
+        logger.error(f"Failed to load {data_name} JSON: {str(e)}")
+        return None
 
-# NumPy 배열로 변환 및 FAISS 인덱스 초기화
-if db_embeddings:
-    db_embeddings = torch.stack(db_embeddings)  # Keep on GPU
-    print(f"Embeddings tensor shape: {db_embeddings.shape}")
+# 이미지 다운로드를 위한 배치 요청을 전송하고 응답을 반환
+def download_images(perfume_image_data):
+    try:
+        response = requests.post("http://localhost:8001/download_images/", json=perfume_image_data)
+        if response.status_code == 200:
+            logger.info("Successfully downloaded images.")
+            return response.json()
+        else:
+            logger.error(f"Failed to download images. Status code: {response.status_code}")
+            return None
+    except Exception as e:
+        logger.error(f"Error during image downloading: {e}")
+        return None
 
-    # 코사인 유사도를 위한 임베딩 정규화
-    db_embeddings = db_embeddings / db_embeddings.norm(dim=1, keepdim=True)
+# 다운로드된 이미지에 대해 임베딩 계산을 위한 배치 요청을 전송
+def compute_embeddings(downloaded_images):
+    try:
+        response = requests.post("http://localhost:8001/get_or_compute_embeddings/", json=downloaded_images)
+        if response.status_code == 200:
+            logger.info("Successfully computed embeddings.")
+            return response.json()
+        else:
+            logger.error(f"Failed to compute embeddings. Status code: {response.status_code}")
+            return None
+    except Exception as e:
+        logger.error(f"Error during embedding computation: {e}")
+        return None
 
-    # 코사인 유사도를 위한 FAISS 인덱스 생성
-    dimension = db_embeddings.shape[1]
-    res = faiss.StandardGpuResources()
-    index = faiss.GpuIndexFlatIP(res, dimension)
-    index.add(db_embeddings)  # Add normalized embeddings
-else:
-    print("No embeddings generated. Initializing empty FAISS index.")
-    res = faiss.StandardGpuResources()
-    index = faiss.GpuIndexFlatIP(res, 1)  # 빈 인덱스 생성
+# DB에 이미지 및 임베딩 데이터 저장
+def populate_db(downloaded_images, embeddings_data):
+    global db_images, db_embeddings
 
+    for item in embeddings_data:
+        if item["status"] == "success":
+            db_images.append({"id": item["id"], "url": item["url"]})
+            embedding = torch.tensor(item["embedding"])
+            db_embeddings.append(embedding)
+        else:
+            logger.error(f"Failed to process embedding for image ID {item['id']} from URL {item['url']}: {item['error']}")
+
+# 계산된 임베딩을 사용하여 FAISS 인덱스를 생성
+def create_faiss_index():
+    global db_embeddings, index
+
+    if db_embeddings:
+        db_embeddings = torch.stack(db_embeddings)
+        db_embeddings = db_embeddings / db_embeddings.norm(dim=1, keepdim=True)
+
+        dimension = db_embeddings.shape[1]
+        index = faiss.GpuIndexFlatIP(faiss.StandardGpuResources(), dimension)
+        index.add(db_embeddings.numpy())
+        logger.info("FAISS index created successfully.")
+    else:
+        logger.info("No embeddings available. Initializing an empty FAISS index.")
+        index = faiss.GpuIndexFlatIP(faiss.StandardGpuResources(), 1)
+
+# 임베딩값으로 향수 매칭
+def get_matching_perfumes(embedding, db_images, db_embeddings, perfume_data, threshold=0.3):
+    # FAISS 인덱스에서 검색
+    D, I = index.search(np.array(embedding).reshape(1, -1), k=10)
+
+    results = [
+        {
+            "index": int(i),
+            "id": db_images[i]["id"],
+            "url": db_images[i]["url"],
+            "similarity": float(D[0][idx]),
+        }
+        for idx, i in enumerate(I[0])
+        if float(D[0][idx]) > threshold
+    ]
+
+    ids = [result["id"] for result in results]
+    matching_perfumes = [
+        {
+            "id": item["id"],
+            "name": item["name"],
+            "brand": item["brand"],
+            "description": item["description"],
+            "similarity": next(
+                (result["similarity"] for result in results if result["id"] == item["id"]), None
+            ),
+            "url": next(
+                (result["url"] for result in results if result["id"] == item["id"]), None
+            ),
+        }
+        for item in perfume_data if item["id"] in ids
+    ]
+
+    return sorted(matching_perfumes, key=lambda x: x["similarity"], reverse=True)
 
 @app.post("/get_perfume_details/")
 async def search_image(file: UploadFile = File(...)):
-    image_bytes = await file.read()
-
     try:
-        image = Image.open(io.BytesIO(image_bytes)).convert("RGB")
+        # GPU 임베딩 서비스 호출
+        image_bytes = await file.read()
 
-        image_bytes = io.BytesIO()
-        image.save(image_bytes, format="PNG")
-        image_bytes.seek(0)
-        output_image_bytes = remove(image_bytes.getvalue())
-
-        output_image = Image.open(io.BytesIO(output_image_bytes)).convert("RGBA")
-
-        # 배경 흰색으로 설정
-        white_background = Image.new("RGBA", output_image.size, "WHITE")
-        white_background.paste(output_image, mask=output_image)
-        final_image = white_background.convert("RGB")
-
-        # 업로드된 이미지 임베딩 계산
-        query_embedding = compute_embedding(final_image).flatten()
-        # query_embedding = query_embedding / query_embedding.norm()  # Normalize
-        query_embedding = torch.tensor(query_embedding)
-        query_embedding = query_embedding / query_embedding.norm()
-
-        # FAISS 인덱스에서 검색
-        D, I = index.search(query_embedding.cpu().detach().numpy().reshape(1, -1), k=10)
-
-        # 결과 생성
-        threshold = 0.3
-        results = [
-            {
-                "index": int(i),
-                "id": db_images[i]["id"],
-                "url": db_images[i]["url"],
-                "similarity": float(D[0][idx]),  # 코사인 유사도 점수
-            }
-            for idx, i in enumerate(I[0])
-            if float(D[0][idx]) > threshold
-        ]
-
-        with open("perfume.json", "r", encoding="utf-8") as f:
-            perfume_data = json.load(f)
-
-        # ID 추출
-        ids = [result["id"] for result in results]
-
-        # 해당 ID에 대한 향수 정보 반환
-        matching_perfumes = [
-            {
-                "id": item["id"],
-                "name": item["name"],
-                "brand": item["brand"],
-                "description": item["description"],
-                "similarity": next(
-                    (
-                        result["similarity"]
-                        for result in results
-                        if result["id"] == item["id"]
-                    ),
-                    None,
-                ),
-                "url": next(
-                    (result["url"] for result in results if result["id"] == item["id"]),
-                    None,
-                ),
-            }
-            for item in perfume_data
-            if item["id"] in ids
-        ]
-
-        matching_perfumes = sorted(
-            matching_perfumes, key=lambda x: x["similarity"], reverse=True
+        compute_url = "http://localhost:8001/compute_embedding_of_uploaded_file/"
+        response = requests.post(
+            compute_url, files={"file": ("uploaded_image.png", image_bytes)}
         )
 
-        return {"perfumes": matching_perfumes}
+        if response.status_code == 200:
+            embedding = response.json().get("embedding")
+            
+            if embedding is not None:
+                matching_perfumes = get_matching_perfumes(embedding, db_images, db_embeddings, perfume_data)
+
+                return {"perfumes": sorted(matching_perfumes, key=lambda x: x["similarity"], reverse=True)}
+            else:
+                return {"error": "No embedding found in the response"}
+        else:
+            return {"error": f"Failed to get embedding. Status code: {response.status_code}"}
     except Exception as e:
-        print(f"Error retrieving perfume details: {e}")
+        logger.error(f"Error retrieving perfume details: {e}")
         return {"error": str(e)}

--- a/Back/model_service.py
+++ b/Back/model_service.py
@@ -1,0 +1,123 @@
+# uvicorn model_service:app --host 127.0.0.1 --port 8001
+from typing import List
+from fastapi import FastAPI, File, UploadFile, Query
+from fastapi.middleware.cors import CORSMiddleware
+from openai import BaseModel
+from transformers import AutoModel
+from PIL import Image
+import io, os, hashlib, torch, requests, logging
+from rembg import remove
+import numpy as np
+from schemas import PerfumeImageItem, PerfumeImageResult, PerfumeEmbeddingResult
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# GPU 모델 로드
+device = "cuda" if torch.cuda.is_available() else "cpu"
+model = AutoModel.from_pretrained("jinaai/jina-clip-v2", trust_remote_code=True).to(device)
+
+# 캐시 디렉토리 설정
+CACHE_DIR = "./image_cache"
+EMBEDDING_CACHE_DIR = "./embedding_cache"
+os.makedirs(CACHE_DIR, exist_ok=True)
+os.makedirs(EMBEDDING_CACHE_DIR, exist_ok=True)
+
+app = FastAPI()
+
+# URL 해시 생성 함수
+def generate_hash(url):
+    return hashlib.md5(url.encode("utf-8")).hexdigest()
+
+# URL에서 이미지를 다운로드하고 캐싱하는 함수
+@app.post("/download_images/", response_model=List[PerfumeImageResult])
+async def download_image_with_cache(perfume_image_data: List[PerfumeImageItem]):
+    results = []
+    for item in perfume_image_data:
+        try:
+            filename = os.path.basename(item.url.split("?")[0])  # Remove query parameters
+            local_path = os.path.join(CACHE_DIR, filename)
+
+            # 이미 캐시된 이미지인지 확인
+            if os.path.exists(local_path):
+                logger.info(f"Using cached image: {local_path}")
+                results.append({"id": item.id, "url": item.url, "local_path": local_path, "status": "success"})
+            else:
+                logger.info(f"Downloading image: {item.url}")
+                response = requests.get(item.url, stream=True)
+                response.raise_for_status()
+
+                # 이미지 로컬에 저장
+                with open(local_path, "wb") as f:
+                    f.write(response.content)
+
+                results.append({"id": item.id, "url": item.url, "local_path": local_path, "status": "success"})
+        except Exception as e:
+            logger.error(f"Failed to process image ID {item.id} from URL {item.url}: {e}")
+            results.append({"id": item.id, "url": item.url, "error": str(e), "status": "failed"})
+
+    return results
+
+# 임베딩 생성 또는 캐싱
+@app.post("/get_or_compute_embeddings/", response_model=List[PerfumeEmbeddingResult])
+async def get_or_compute_embeddings(downloaded_perfume_image_data: List[PerfumeImageResult]):
+    results = []
+    for item in downloaded_perfume_image_data:
+        try:
+            # URL 기반으로 해시 생성
+            url_hash = generate_hash(item.url)
+            embedding_path = os.path.join(EMBEDDING_CACHE_DIR, f"{url_hash}.npy")
+
+            # 캐시된 임베딩 파일이 존재하면 불러오기
+            if os.path.exists(embedding_path):
+                logger.info(f"Using cached embedding for URL: {item.url}")
+                embedding = np.load(embedding_path)
+                results.append({"id": item.id, "url": item.url, "embedding": embedding.tolist(), "status": "success"})
+            else:
+                # 캐시된 임베딩 파일이 존재하지 않으면 이미지 다운로드하고 임베딩 계산
+                response = requests.get(item.url, stream=True)
+                response.raise_for_status()
+                image = Image.open(io.BytesIO(response.content)).convert("RGB")
+
+                # 임베딩 생성
+                logger.info(f"Computing embedding for URL: {item.url}")
+                embedding = model.encode_image(image).flatten()
+
+                # Normalize & 임베딩 저장
+                embedding = embedding / np.linalg.norm(embedding)
+                np.save(embedding_path, embedding)
+
+                results.append({"id": item.id, "url": item.url, "embedding": embedding.tolist(), "status": "success"})
+        except Exception as e:
+            logger.error(f"Failed to compute embedding for URL {item.url}: {e}")
+            results.append({"id": item.id, "url": item.url, "error": str(e), "status": "failed"})
+
+    return results
+
+# GPU에서 실행되는 임베딩 생성 함수
+@app.post("/compute_embedding_of_uploaded_file/")
+async def compute_embedding(file: UploadFile = File(...)):
+    try:
+        image_bytes = await file.read()
+        image = Image.open(io.BytesIO(image_bytes)).convert("RGB")
+
+        # 배경 제거
+        image_bytes = io.BytesIO()
+        image.save(image_bytes, format="PNG")
+        image_bytes.seek(0)
+        output_image_bytes = remove(image_bytes.getvalue())
+
+        output_image = Image.open(io.BytesIO(output_image_bytes)).convert("RGBA")
+
+        white_background = Image.new("RGBA", output_image.size, "WHITE")
+        white_background.paste(output_image, mask=output_image)
+        final_image = white_background.convert("RGB")
+
+        # 임베딩 계산
+        embedding = model.encode_image(final_image).flatten()
+        embedding = torch.tensor(embedding)
+        embedding = embedding / embedding.norm()
+
+        return {"embedding": embedding.cpu().detach().numpy().tolist()}
+    except Exception as e:
+        return {"error": str(e)}

--- a/Back/schemas.py
+++ b/Back/schemas.py
@@ -1,0 +1,21 @@
+from pydantic import BaseModel
+from typing import Optional, List
+
+class PerfumeImageItem(BaseModel):
+    id: int
+    url: str
+    perfume_id: int
+
+class PerfumeImageResult(BaseModel):
+    id: int
+    url: str
+    status: str
+    local_path: Optional[str] = None
+    error: Optional[str] = None
+
+class PerfumeEmbeddingResult(BaseModel):
+    id: int
+    url: str
+    status: str
+    embedding: Optional[List[float]] = None
+    error: Optional[str] = None


### PR DESCRIPTION
- 모델 관련 로직을 model_service.py로 분리
   - download_images와 get_or_compute_embeddings API를 배치 처리 방식으로 리팩토링
   - 개별 API 호출 수를 줄여 효율성 향상
   - 성공 및 오류 처리를 추가하고, 구조화된 결과 아이템 생성
- 검색 관련 로직은 main.py에 유지
- 반환 결과 구조를 위한 새로운 스키마 클래스 생성 (구조화된 API 응답을 위한 새로운 클래스 추가)